### PR TITLE
Sensing Location Fix in onTheMap

### DIFF
--- a/engine/src/main/battlecode/world/RobotControllerImpl.java
+++ b/engine/src/main/battlecode/world/RobotControllerImpl.java
@@ -153,10 +153,12 @@ public final strictfp class RobotControllerImpl implements RobotController {
     @Override
     public boolean onTheMap(MapLocation loc) throws GameActionException {
         assertNotNull(loc);
+         if (!this.gameWorld.getGameMap().onTheMap(loc))
+            return false;
         if (!this.robot.canSenseLocation(loc))
             throw new GameActionException(CANT_SENSE_THAT,
                     "Target location not within vision range");
-        return this.gameWorld.getGameMap().onTheMap(loc);
+        return true;
     }
 
     private void assertCanSenseLocation(MapLocation loc) throws GameActionException {


### PR DESCRIPTION
Reorder onTheMap to first check if a location is on the map and then check if the location is able to sensed by a robot.
Fixes a recurring array out of bounds error when InternalRobot's canSenseLocation checks if the location has a cloud to determine the vision radius but the location is out of map bounds. 