### PR TITLE
Don't check islands off the map

### DIFF
--- a/engine/src/main/battlecode/server/Server.java
+++ b/engine/src/main/battlecode/server/Server.java
@@ -233,7 +233,7 @@ public strictfp class Server implements Runnable {
         seenLocations.add(mapLocation);
         for (Direction dir : Direction.cardinalDirections()) {
             MapLocation newLocation = mapLocation.add(dir);
-            if (seenLocations.contains(newLocation)) {continue;}
+            if (seenLocations.contains(newLocation) || !liveMap.onTheMap(newLocation)) {continue;}
             if (islandArray[locationToIndex(liveMap, newLocation)] == currValue) {
                 extendOut(liveMap, newLocation, seenLocations);
             }


### PR DESCRIPTION
Bug with custom map, had island at map edge.

```
> Task :run FAILED
Stack trace: 
java.lang.ArrayIndexOutOfBoundsException: 3658
        at battlecode.server.Server.extendOut(Server.java:237)
        at battlecode.server.Server.validateMapOnGuarantees(Server.java:336)
        at battlecode.server.Server.runMatch(Server.java:466)
        at battlecode.server.Server.run(Server.java:180)
        at battlecode.server.Main.runHeadless(Main.java:76)
        at battlecode.server.Main.run(Main.java:108)
        at battlecode.server.Main.main(Main.java:117)
[server:warning] java version "1.8.0_292"
[server:warning] OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
[server:warning] Please report this to the 6.9610 devs, by posting to the forum
[server:warning] under the "bugs" thread.  Include a copy of this printout and
[server:warning] a brief description of the bug, including whether it's consistent
[server:warning] or sporadic.  Thanks!
invalid bc.server.mode

FAILURE: Build failed with an exception.
```
