### PR TITLE
Show sprint 2 maps in client and improve map type filters

### DIFF
--- a/client/visualizer/src/constants.ts
+++ b/client/visualizer/src/constants.ts
@@ -148,22 +148,12 @@ export enum MapType {
   DEFAULT,
   SPRINT_1,
   SPRINT_2,
-  // INTL_QUALIFYING,
-  // US_QUALIFYING,
-  // HS_NEWBIE,
-  // FINAL,
+  INTL_QUALIFYING,
+  US_QUALIFYING,
+  HS_NEWBIE,
+  FINAL,
   CUSTOM
 };
-
-// Map types to filter in runner
-export const mapTypes: MapType[] = [MapType.DEFAULT,
-MapType.SPRINT_1,
-// MapType.SPRINT_2,
-// MapType.INTL_QUALIFYING,
-// MapType.US_QUALIFYING,
-// MapType.HS_NEWBIE,
-// MapType.FINAL,
-MapType.CUSTOM]
 
 export const SERVER_MAPS: Map<string, MapType> = new Map<string, MapType>([
   ["AllElements", MapType.DEFAULT],

--- a/client/visualizer/src/sidebar/mapfilter.ts
+++ b/client/visualizer/src/sidebar/mapfilter.ts
@@ -107,8 +107,12 @@ export default class MapFilter {
     this.filterName.onkeyup = () => { this.applyFilter() };
     this.filterName.onchange = () => { this.applyFilter() };
 
+    const serverMapTypes = new Set(cst.SERVER_MAPS.values());
+    const sortedMapTypes = Object.keys(MapType).map(Number).filter(item => !isNaN(item));
+    const mapTypesToRender = sortedMapTypes.filter(type => type === cst.MapType.CUSTOM || serverMapTypes.has(type));
+
     // Filter for map type
-    for (let type of cst.mapTypes) {
+    for (let type of mapTypesToRender) {
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.value = String(type);
@@ -143,12 +147,12 @@ export default class MapFilter {
   private mapTypeToString(type: MapType): string {
     switch(type) {
       case MapType.DEFAULT: return "Default";
-      // case MapType.SPRINT_1: return "Sprint 1";
-      // case MapType.SPRINT_2: return "Sprint 2";
-      // case MapType.INTL_QUALIFYING: return "Intl Quals";
-      // case MapType.US_QUALIFYING: return "US Quals";
-      // case MapType.HS_NEWBIE: return "HS and Newbie";
-      // case MapType.FINAL: return "Final";
+      case MapType.SPRINT_1: return "Sprint 1";
+      case MapType.SPRINT_2: return "Sprint 2";
+      case MapType.INTL_QUALIFYING: return "Intl Quals";
+      case MapType.US_QUALIFYING: return "US Quals";
+      case MapType.HS_NEWBIE: return "HS and Newbie";
+      case MapType.FINAL: return "Final";
       default: return "Custom";
     }
   }


### PR DESCRIPTION
- Made sprint 2 maps show in the client.
- Fixed sprint 1 maps being categorized as "Custom" in the map type filters.
- Changed the logic that renders the map type filters so that you no longer need to manually update `MapType` and `mapTypes` when adding server maps to the client. Instead, after updating `SERVER_MAPS` the new map types will automatically show up in the runner tab.

Before:
![](https://user-images.githubusercontent.com/14951909/214553377-428f39b5-c45b-4d6b-acc8-287eecaa8e61.png)

After:
![](https://user-images.githubusercontent.com/14951909/214553339-04daee05-bf16-464a-9193-fc59bb395cc7.png)